### PR TITLE
feat: adicionar validação para existência do tecnico

### DIFF
--- a/src/main/java/br/com/filipecode/DeskhelpApi/tecnico/controller/TecnicoController.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/tecnico/controller/TecnicoController.java
@@ -47,12 +47,7 @@ public class TecnicoController {
     public ResponseEntity<Optional<TecnicoRespostaDTO>> buscarTecnicoPorId(@PathVariable String id) {
        UUID tecnicoId = UUID.fromString(id);
 
-        Optional<TecnicoRespostaDTO> tecnicoRespostaDTO = tecnicoService.buscarDetalhesPorId(tecnicoId);
-
-       if (tecnicoRespostaDTO.isPresent()) {
-           return ResponseEntity.ok(tecnicoRespostaDTO);
-       }
-
+       tecnicoService.buscarDetalhesPorId(tecnicoId);
        return ResponseEntity.notFound().build();
     }
 
@@ -66,13 +61,8 @@ public class TecnicoController {
     @DeleteMapping("{id}")
     public ResponseEntity<Void> deletarTecnico(@PathVariable String id) {
         UUID tecnicoId = UUID.fromString(id);
-        Optional<Tecnico> possivelTecnico = tecnicoService.listarPorId(tecnicoId);
-
-        if (possivelTecnico.isEmpty()) {
-            return ResponseEntity.notFound().build();
-        }
-
         tecnicoService.deletarPorId(tecnicoId);
+
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/br/com/filipecode/DeskhelpApi/tecnico/service/TecnicoService.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/tecnico/service/TecnicoService.java
@@ -1,5 +1,6 @@
 package br.com.filipecode.DeskhelpApi.tecnico.service;
 
+import br.com.filipecode.DeskhelpApi.shared.exceptions.EntidadeNaoEncontradaException;
 import br.com.filipecode.DeskhelpApi.tecnico.dto.TecnicoDTO;
 import br.com.filipecode.DeskhelpApi.tecnico.dto.TecnicoRespostaDTO;
 import br.com.filipecode.DeskhelpApi.tecnico.entity.Tecnico;
@@ -32,7 +33,11 @@ public class TecnicoService {
 
     public void atualizarTecnico(UUID id, TecnicoDTO tecnicoDTO) {
         Tecnico tecnico = tecnicoRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Tecnico não encontrado!"));
+                        .orElseThrow(() -> new EntidadeNaoEncontradaException("Técnico não encontrado!"));
+
+        if (!tecnico.getEmail().equals(tecnicoDTO.email())) {
+            tecnicoValidator.validarEmailDuplicado(tecnicoDTO.email());
+        }
 
         tecnico.setNome(tecnicoDTO.nome());
         tecnico.setEmail(tecnicoDTO.email());
@@ -42,11 +47,8 @@ public class TecnicoService {
 
     }
 
-    public Optional<Tecnico> listarPorId(UUID id) {
-        return tecnicoRepository.findById(id);
-    }
-
     public Optional<TecnicoRespostaDTO> buscarDetalhesPorId(UUID id) {
+        tecnicoValidator.validarTecnicoExiste(id);
         return tecnicoRepository.findById(id)
                 .map(tecnico -> new TecnicoRespostaDTO(
                         tecnico.getId(),
@@ -77,6 +79,7 @@ public class TecnicoService {
     }
 
     public void deletarPorId(UUID id) {
+        tecnicoValidator.validarTecnicoExiste(id);
         tecnicoRepository.deleteById(id);
     }
 }

--- a/src/main/java/br/com/filipecode/DeskhelpApi/tecnico/validator/TecnicoValidator.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/tecnico/validator/TecnicoValidator.java
@@ -1,9 +1,12 @@
 package br.com.filipecode.DeskhelpApi.tecnico.validator;
 
+import br.com.filipecode.DeskhelpApi.shared.exceptions.EntidadeNaoEncontradaException;
 import br.com.filipecode.DeskhelpApi.shared.exceptions.RegistroDuplicadoException;
 import br.com.filipecode.DeskhelpApi.tecnico.repository.TecnicoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -15,5 +18,10 @@ public class TecnicoValidator {
         if (tecnicoRepository.existsByEmail(email)) {
             throw new RegistroDuplicadoException("Já existe um tecnico cadastrado com o email informado!");
         }
+    }
+
+    public void validarTecnicoExiste(UUID id) {
+        tecnicoRepository.findById(id)
+                .orElseThrow(() -> new EntidadeNaoEncontradaException("Técnico não encontrado!"));
     }
 }


### PR DESCRIPTION

Este PR implementa melhorias na lógica de atualização, listagem e exclusão de técnicos, além de adicionar validações essenciais para garantir integridade dos dados:
✅ Adicionada validação de email duplicado ao atualizar um técnico.

 Lógica ajustada para verificar se o email foi realmente alterado antes de validar duplicidade.

Removido o método listarPorId() que estava sendo utilizado apenas no controller para validação — agora a responsabilidade está centralizada no service via validarTecnicoExiste().

Manutenção da responsabilidade única: controller apenas invoca métodos do service, mantendo o fluxo limpo e desacoplado.