### PR TITLE
feat: adiciona validação de alteração em chamados concluídos

### DIFF
--- a/src/main/java/br/com/filipecode/DeskhelpApi/chamado/service/ChamadoService.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/chamado/service/ChamadoService.java
@@ -5,8 +5,10 @@ import br.com.filipecode.DeskhelpApi.chamado.dto.ChamadoDTO;
 import br.com.filipecode.DeskhelpApi.chamado.dto.ChamadoRespostaDTO;
 import br.com.filipecode.DeskhelpApi.chamado.entity.Chamado;
 import br.com.filipecode.DeskhelpApi.auditoria.service.AuditoriaService;
+import br.com.filipecode.DeskhelpApi.chamado.validator.ChamadoValidador;
 import br.com.filipecode.DeskhelpApi.shared.enums.Prioridade;
 import br.com.filipecode.DeskhelpApi.shared.enums.Status;
+import br.com.filipecode.DeskhelpApi.shared.exceptions.EntidadeNaoEncontradaException;
 import br.com.filipecode.DeskhelpApi.tecnico.entity.Tecnico;
 import br.com.filipecode.DeskhelpApi.usuario.entity.Usuario;
 import br.com.filipecode.DeskhelpApi.chamado.repository.ChamadoRepository;
@@ -29,6 +31,7 @@ public class ChamadoService {
     private final UsuarioRepository usuarioRepository;
     private final TecnicoRepository tecnicoRepository;
     private final AuditoriaService auditoriaService;
+    private final ChamadoValidador chamadoValidador;
 
     public void criarChamado(ChamadoDTO chamadoDTO) {
         Usuario usuario = usuarioRepository.findById(chamadoDTO.usuarioId())
@@ -111,9 +114,7 @@ public class ChamadoService {
     }
 
     public void atualizarChamadoParcial(UUID id, AtualizarChamadoDTO atualizarChamadoDTO) {
-        Chamado chamado = chamadoRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Chamado não encontrado!"));
-
+        Chamado chamado = chamadoValidador.validarChamadoPodeSerAlterado(id);
         StringBuilder descricaoEvento = new StringBuilder("Chamado atualizado: ");
 
 
@@ -132,13 +133,9 @@ public class ChamadoService {
             descricaoEvento.append("técnico atribuído: ").append(tecnico.getNome()).append(". ");
 
         }
-
         chamado.setDataAtualizacao(LocalDateTime.now());
+
         chamadoRepository.save(chamado);
-
         auditoriaService.registrarEvento(chamado, descricaoEvento.toString().trim());
-
     }
-
-
 }

--- a/src/main/java/br/com/filipecode/DeskhelpApi/chamado/validator/ChamadoValidador.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/chamado/validator/ChamadoValidador.java
@@ -1,0 +1,30 @@
+package br.com.filipecode.DeskhelpApi.chamado.validator;
+
+import br.com.filipecode.DeskhelpApi.chamado.entity.Chamado;
+import br.com.filipecode.DeskhelpApi.chamado.repository.ChamadoRepository;
+
+import br.com.filipecode.DeskhelpApi.shared.enums.Status;
+import br.com.filipecode.DeskhelpApi.shared.exceptions.EntidadeNaoEncontradaException;
+import br.com.filipecode.DeskhelpApi.shared.exceptions.RequisicaoInvalidadeException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ChamadoValidador {
+
+    private final ChamadoRepository chamadoRepository;
+
+    public Chamado validarChamadoPodeSerAlterado(UUID id) {
+        Chamado chamado = chamadoRepository.findById(id)
+                .orElseThrow(() -> new EntidadeNaoEncontradaException("Chamado não encontrado!"));
+
+        if (chamado.getStatus() == Status.CONCLUIDO) {
+            throw new RequisicaoInvalidadeException("Chamado já foi concluido e não pode ser alterado!");
+        }
+
+        return chamado;
+    }
+}

--- a/src/main/java/br/com/filipecode/DeskhelpApi/shared/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/shared/exceptions/GlobalExceptionHandler.java
@@ -23,4 +23,11 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.NOT_FOUND)
                 .body(Map.of("erro", exception.getMessage()));
     }
+
+    @ExceptionHandler
+    public ResponseEntity<?> handleRequisicaoInvalida(RequisicaoInvalidadeException exception) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("erro", exception.getMessage()));
+    }
 }

--- a/src/main/java/br/com/filipecode/DeskhelpApi/shared/exceptions/RequisicaoInvalidadeException.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/shared/exceptions/RequisicaoInvalidadeException.java
@@ -1,0 +1,7 @@
+package br.com.filipecode.DeskhelpApi.shared.exceptions;
+
+public class RequisicaoInvalidadeException extends RuntimeException {
+    public RequisicaoInvalidadeException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION

Implementa a exceção personalizada 
RequisicaoInvalidadeException para impedir alterações em chamados com status CONCLUIDO.
A lógica foi centralizada no ChamadoValidator por meio do método validarChamadoPodeSerAlterado(UUID id), que agora também retorna o chamado validado.
Essa abordagem melhora a legibilidade e centraliza as regras de negócio referentes ao status do chamado.
