### PR TITLE
Adiciona usuário ADMIN automático

### DIFF
--- a/src/main/java/br/com/filipecode/DeskhelpApi/shared/config/UsuarioAdminInitializer.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/shared/config/UsuarioAdminInitializer.java
@@ -1,0 +1,38 @@
+package br.com.filipecode.DeskhelpApi.shared.config;
+
+import br.com.filipecode.DeskhelpApi.usuario.entity.Usuario;
+import br.com.filipecode.DeskhelpApi.usuario.enums.Role;
+import br.com.filipecode.DeskhelpApi.usuario.repository.UsuarioRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+public class UsuarioAdminInitializer {
+
+    private final UsuarioRepository usuarioRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @PostConstruct
+    public void criarDefaultAdmin() {
+        // Usuário de teste para desenvolvimento
+
+        if (usuarioRepository.count() == 0) {
+            Usuario admin = new Usuario();
+
+            admin.setNome("admin");
+            admin.setEmail("admin@gmail.com");
+            admin.setSenha(passwordEncoder.encode("admin123"));
+            admin.setRole(Role.ADMIN);
+            admin.setDepartamento("Administração Sistema");
+            admin.setCargo("Administrador");
+
+            usuarioRepository.save(admin);
+            System.out.println("Usuário ADMIN criado com sucesso");
+        } else {
+            System.out.println("Usuário ADMIN já existe. Nenhuma ação necessária");
+        }
+    }
+}


### PR DESCRIPTION
##  Criação automática do usuário ADMIN 

### O que foi feito

- Criada uma lógica de inicialização automática com `@PostConstruct` para **gerar um usuário ADMIN padrão** ao subir a aplicação.
- O usuário é criado **somente se o banco de dados estiver vazio** (ou seja, sem registros na tabela de usuários).
- A senha utilizada (`admin123`) está criptografada com BCrypt.

### Por que isso é importante

- Em ambientes novos ou durante o desenvolvimento, é comum subir um banco limpo, o que impossibilita o login se não houver um usuário ADMIN.
- Essa implementação garante que o sistema fique acessível mesmo após mudanças de máquina ou reconfiguração do banco.
- Evita a necessidade de liberar endpoints publicamente ou inserir manualmente via banco.

### Observações

- A senha e o email do ADMIN estão visíveis no código por se tratar de um **projeto pessoal e de estudo**.
- Caso o projeto evolua para algo mais sério ou seja colocado em produção, essa lógica deve ser:
  - **Removida** ou **restringida por perfil (`@Profile("dev")`)**
  - A senha deve ser **armazenada com mais segurança** (ex: variáveis de ambiente)

### Dados do usuário criado

```json
{
  "nome": "Administrador",
  "email": "admin@gmail.com",
  "senha": "admin123",
  "role": "ADMIN"
}
