### PR TITLE
Atualizacao parcial

### DIFF
--- a/src/main/java/br/com/filipecode/DeskhelpApi/chamado/validator/ChamadoValidador.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/chamado/validator/ChamadoValidador.java
@@ -5,8 +5,7 @@ import br.com.filipecode.DeskhelpApi.chamado.repository.ChamadoRepository;
 
 import br.com.filipecode.DeskhelpApi.chamado.enums.Status;
 import br.com.filipecode.DeskhelpApi.shared.exceptions.EntidadeNaoEncontradaException;
-import br.com.filipecode.DeskhelpApi.shared.exceptions.RequisicaoInvalidadeException;
-import br.com.filipecode.DeskhelpApi.usuario.enums.Role;
+import br.com.filipecode.DeskhelpApi.shared.exceptions.RequisicaoInvalidaException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +22,7 @@ public class ChamadoValidador {
                 .orElseThrow(() -> new EntidadeNaoEncontradaException("Chamado não encontrado!"));
 
         if (chamado.getStatus() == Status.CONCLUIDO) {
-            throw new RequisicaoInvalidadeException("Chamado já foi concluido e não pode ser alterado!");
+            throw new RequisicaoInvalidaException("Chamado já foi concluido e não pode ser alterado!");
         }
 
         return chamado;

--- a/src/main/java/br/com/filipecode/DeskhelpApi/shared/config/UsuarioAdminInitializer.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/shared/config/UsuarioAdminInitializer.java
@@ -1,0 +1,38 @@
+package br.com.filipecode.DeskhelpApi.shared.config;
+
+import br.com.filipecode.DeskhelpApi.usuario.entity.Usuario;
+import br.com.filipecode.DeskhelpApi.usuario.enums.Role;
+import br.com.filipecode.DeskhelpApi.usuario.repository.UsuarioRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+public class UsuarioAdminInitializer {
+
+    private final UsuarioRepository usuarioRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @PostConstruct
+    public void criarDefaultAdmin() {
+        // Usuário de teste para desenvolvimento
+
+        if (usuarioRepository.count() == 0) {
+            Usuario admin = new Usuario();
+
+            admin.setNome("admin");
+            admin.setEmail("admin@gmail.com");
+            admin.setSenha(passwordEncoder.encode("admin123"));
+            admin.setRole(Role.ADMIN);
+            admin.setDepartamento("Administração Sistema");
+            admin.setCargo("Administrador");
+
+            usuarioRepository.save(admin);
+            System.out.println("Usuário ADMIN criado com sucesso");
+        } else {
+            System.out.println("Usuário ADMIN já existe. Nenhuma ação necessária");
+        }
+    }
+}

--- a/src/main/java/br/com/filipecode/DeskhelpApi/shared/exceptions/RequisicaoInvalidaException.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/shared/exceptions/RequisicaoInvalidaException.java
@@ -1,0 +1,7 @@
+package br.com.filipecode.DeskhelpApi.shared.exceptions;
+
+public class RequisicaoInvalidaException extends RuntimeException {
+    public RequisicaoInvalidaException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/com/filipecode/DeskhelpApi/shared/exceptions/RequisicaoInvalidadeException.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/shared/exceptions/RequisicaoInvalidadeException.java
@@ -1,7 +1,0 @@
-package br.com.filipecode.DeskhelpApi.shared.exceptions;
-
-public class RequisicaoInvalidadeException extends RuntimeException {
-    public RequisicaoInvalidadeException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/br/com/filipecode/DeskhelpApi/shared/handler/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/shared/handler/GlobalExceptionHandler.java
@@ -3,7 +3,7 @@ package br.com.filipecode.DeskhelpApi.shared.handler;
 import br.com.filipecode.DeskhelpApi.shared.dto.ErroPadronizadoDTO;
 import br.com.filipecode.DeskhelpApi.shared.exceptions.EntidadeNaoEncontradaException;
 import br.com.filipecode.DeskhelpApi.shared.exceptions.RegistroDuplicadoException;
-import br.com.filipecode.DeskhelpApi.shared.exceptions.RequisicaoInvalidadeException;
+import br.com.filipecode.DeskhelpApi.shared.exceptions.RequisicaoInvalidaException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -42,7 +42,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErroPadronizadoDTO> handleRequisicaoInvalida(RequisicaoInvalidadeException exception, HttpServletRequest request) {
+    public ResponseEntity<ErroPadronizadoDTO> handleRequisicaoInvalida(RequisicaoInvalidaException exception, HttpServletRequest request) {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(erro(HttpStatus.BAD_REQUEST,

--- a/src/main/java/br/com/filipecode/DeskhelpApi/usuario/controller/UsuarioController.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/usuario/controller/UsuarioController.java
@@ -77,7 +77,7 @@ public class UsuarioController {
 
     @PutMapping("{id}")
     @PreAuthorize("hasAnyRole('TECNICO', 'ADMIN')")
-    public ResponseEntity<Object> atualizarUsuario(@PathVariable String id,
+    public ResponseEntity<Void> atualizarUsuario(@PathVariable String id,
                                                    @RequestBody @Valid AtualizarUsuarioDTO dto) {
         UUID usuarioId = UUID.fromString(id);
         usuarioService.atualizarUsuario(usuarioId, dto);

--- a/src/main/java/br/com/filipecode/DeskhelpApi/usuario/controller/UsuarioController.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/usuario/controller/UsuarioController.java
@@ -1,6 +1,7 @@
 package br.com.filipecode.DeskhelpApi.usuario.controller;
 
 import br.com.filipecode.DeskhelpApi.usuario.dto.request.AtualizarUsuarioDTO;
+import br.com.filipecode.DeskhelpApi.usuario.dto.request.AtualizarUsuarioParcialDTO;
 import br.com.filipecode.DeskhelpApi.usuario.dto.request.UsuarioDTO;
 import br.com.filipecode.DeskhelpApi.usuario.dto.response.UsuarioRespostaDTO;
 import br.com.filipecode.DeskhelpApi.usuario.enums.Role;
@@ -62,6 +63,17 @@ public class UsuarioController {
 
         return ResponseEntity.created(uri).body(tecnico);
     }
+
+    @PatchMapping("{id}")
+    @PreAuthorize("hasAnyRole('TECNICO', 'ADMIN')")
+    public ResponseEntity<Void> atualizarUsuarioParcial(@PathVariable String id,
+                                                        @RequestBody @Valid AtualizarUsuarioParcialDTO dto) {
+        UUID usuarioId = UUID.fromString(id);
+        usuarioService.atualizarUsuarioParcial(usuarioId, dto);
+
+        return ResponseEntity.noContent().build();
+    }
+
 
     @PutMapping("{id}")
     @PreAuthorize("hasAnyRole('TECNICO', 'ADMIN')")

--- a/src/main/java/br/com/filipecode/DeskhelpApi/usuario/dto/request/AtualizarUsuarioParcialDTO.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/usuario/dto/request/AtualizarUsuarioParcialDTO.java
@@ -1,0 +1,14 @@
+package br.com.filipecode.DeskhelpApi.usuario.dto.request;
+
+import br.com.filipecode.DeskhelpApi.usuario.enums.Role;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+
+public record AtualizarUsuarioParcialDTO(
+        String nome,
+        @Size(min = 6, message = "A senha deve ter no mínimo 6 caracteres") String senha,
+        @Email(message = "Informe um e-mail válido") String email,
+        Role role,
+        String departamento,
+        String cargo) {
+}

--- a/src/main/java/br/com/filipecode/DeskhelpApi/usuario/service/UsuarioService.java
+++ b/src/main/java/br/com/filipecode/DeskhelpApi/usuario/service/UsuarioService.java
@@ -1,7 +1,9 @@
 package br.com.filipecode.DeskhelpApi.usuario.service;
 
 import br.com.filipecode.DeskhelpApi.shared.exceptions.EntidadeNaoEncontradaException;
+import br.com.filipecode.DeskhelpApi.shared.exceptions.RegistroDuplicadoException;
 import br.com.filipecode.DeskhelpApi.usuario.dto.request.AtualizarUsuarioDTO;
+import br.com.filipecode.DeskhelpApi.usuario.dto.request.AtualizarUsuarioParcialDTO;
 import br.com.filipecode.DeskhelpApi.usuario.dto.request.UsuarioDTO;
 import br.com.filipecode.DeskhelpApi.usuario.dto.response.UsuarioRespostaDTO;
 import br.com.filipecode.DeskhelpApi.usuario.entity.Usuario;
@@ -43,13 +45,46 @@ public class UsuarioService {
         return mapearParaRespostaDTO(usuarioSalvo);
     }
 
-    public Usuario atualizarUsuario(UUID id, AtualizarUsuarioDTO atualizarUsuarioDTO) {
+    public void atualizarUsuario(UUID id, AtualizarUsuarioDTO atualizarUsuarioDTO) {
         Usuario usuario = usuarioRepository.findById(id)
                 .orElseThrow(() -> new EntidadeNaoEncontradaException("Usuário não encontrado"));
 
         mapearParaAtualizacaoDTO(usuario, atualizarUsuarioDTO);
 
-        return usuarioRepository.save(usuario);
+        usuarioRepository.save(usuario);
+    }
+
+    public void atualizarUsuarioParcial(UUID id, AtualizarUsuarioParcialDTO dto) {
+        Usuario usuario = usuarioRepository.findById(id)
+                .orElseThrow(() -> new EntidadeNaoEncontradaException("Usuário não encontrado"));
+
+
+        if (dto.nome() != null) {
+            usuario.setNome(dto.nome());
+        }
+        if (dto.senha() != null) {
+            usuario.setSenha(passwordEncoder.encode(dto.senha()));
+        }
+        if (dto.email() != null && !dto.email().equals(usuario.getEmail())) {
+            boolean emailJaUsado = usuarioRepository.existsByEmail(dto.email());
+
+            if (emailJaUsado) {
+                throw new RegistroDuplicadoException("Já existe um usuário com este e-mail");
+            }
+
+            usuario.setEmail(dto.email());
+        }
+        if (dto.role() != null) {
+            usuario.setRole(dto.role());
+        }
+        if (dto.departamento() != null) {
+            usuario.setDepartamento(dto.departamento());
+        }
+        if (dto.cargo() != null) {
+            usuario.setCargo(dto.cargo());
+        }
+
+        usuarioRepository.save(usuario);
     }
 
     public Optional<Usuario> listarPorId(UUID id) {


### PR DESCRIPTION
##  Atualização Parcial de Usuário (HTTP PATCH)

### O que foi feito

- Implementado endpoint `PATCH /usuarios/{id}` permitindo atualização **parcial** dos dados de um usuário.
- Criado DTO exclusivo para atualização parcial (`AtualizarUsuarioParcialDTO`), com todos os campos **opcionais** (permite `null`).
- Adicionada lógica no service para atualizar **apenas os campos enviados** na requisição (`null-safe`).
- Adicionada verificação para que o campo **email** não seja atualizado com um valor já existente no banco.
- Garantido que a **senha só seja atualizada** caso seja enviada, com aplicação de `BCrypt`.

---

### Por que isso é importante

- Evita sobrescrita de dados não enviados na requisição.
- Melhora a flexibilidade da API ao permitir edições específicas.
- Garante a consistência e segurança dos dados (como verificação de email e atualização segura da senha).
- Segue boas práticas REST utilizando `PATCH` para alterações parciais.

---

### Como testar

1. **Envie uma requisição PATCH para `/usuarios/{id}`** com apenas os campos que deseja atualizar.
   Exemplo:
   ```json
   {
     "nome": "Novo nome",
     "senha": "novaSenha123"
   }
